### PR TITLE
Update environment

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -18,7 +18,7 @@ dependencies:
   - joblib
   - rasterio
   - xarray==2022.9.0
-  - scikit-learn
+  - scikit-learn==1.2.2
   - rioxarray
   - pip
   - pip:

--- a/environment.yaml
+++ b/environment.yaml
@@ -20,6 +20,8 @@ dependencies:
   - xarray==2022.9.0
   - scikit-learn==1.2.2
   - rioxarray
+  - geopandas
+  - shapely
   - pip
   - pip:
      - pystemmusscope


### PR DESCRIPTION
Update the environment file for two reasons:

* the RF model is saved in a pickle file. Reading the model fails if the version of scikit-learn in the environment does not match the version used to write the file. For now, I suggest to pin the version of scikit learn, but we should maybe find a better format to store the model. 
* `geopandas` and `shapely`, used in the Europe notebook, are not part of the environment.
